### PR TITLE
fix: Place `schema` property under `meta`

### DIFF
--- a/src/rules/arrayStyle/index.js
+++ b/src/rules/arrayStyle/index.js
@@ -81,7 +81,7 @@ export default (defaultConfig, simpleType) => {
     create,
     meta: {
       fixable: 'code',
+      schema,
     },
-    schema,
   };
 };

--- a/src/rules/arrowParens.js
+++ b/src/rules/arrowParens.js
@@ -155,21 +155,21 @@ export default {
     },
 
     type: 'layout',
-  },
 
-  schema: [
-    {
-      enum: ['always', 'as-needed'],
-    },
-    {
-      additionalProperties: false,
-      properties: {
-        requireForBlockBody: {
-          default: false,
-          type: 'boolean',
-        },
+    schema: [
+      {
+        enum: ['always', 'as-needed'],
       },
-      type: 'object',
-    },
-  ],
+      {
+        additionalProperties: false,
+        properties: {
+          requireForBlockBody: {
+            default: false,
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
 };

--- a/src/rules/booleanStyle.js
+++ b/src/rules/booleanStyle.js
@@ -39,6 +39,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/defineFlowType.js
+++ b/src/rules/defineFlowType.js
@@ -91,5 +91,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/delimiterDangle.js
+++ b/src/rules/delimiterDangle.js
@@ -129,6 +129,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -61,6 +61,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/enforceSuppressionCode.js
+++ b/src/rules/enforceSuppressionCode.js
@@ -48,5 +48,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/genericSpacing.js
+++ b/src/rules/genericSpacing.js
@@ -92,12 +92,10 @@ const create = (context) => {
   };
 };
 
-const meta = {
-  fixable: 'whitespace',
-};
-
 export default {
   create,
-  meta,
-  schema,
+  meta: {
+    fixable: 'whitespace',
+    schema,
+  },
 };

--- a/src/rules/interfaceIdMatch.js
+++ b/src/rules/interfaceIdMatch.js
@@ -29,5 +29,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/newlineAfterFlowAnnotation.js
+++ b/src/rules/newlineAfterFlowAnnotation.js
@@ -67,6 +67,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -90,5 +90,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noFlowFixMeComments.js
+++ b/src/rules/noFlowFixMeComments.js
@@ -56,5 +56,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noFlowSuppressionsInStrictFiles.js
+++ b/src/rules/noFlowSuppressionsInStrictFiles.js
@@ -61,5 +61,7 @@ const create: Rule$Create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noMixed.js
+++ b/src/rules/noMixed.js
@@ -11,5 +11,7 @@ const create = (context) => ({
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noMutableArray.js
+++ b/src/rules/noMutableArray.js
@@ -56,6 +56,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/noPrimitiveConstructorTypes.js
+++ b/src/rules/noPrimitiveConstructorTypes.js
@@ -25,5 +25,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noTypesMissingFileAnnotation.js
+++ b/src/rules/noTypesMissingFileAnnotation.js
@@ -50,5 +50,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/noWeakTypes.js
+++ b/src/rules/noWeakTypes.js
@@ -77,5 +77,7 @@ const create: Rule$Create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/objectTypeCurlySpacing.js
+++ b/src/rules/objectTypeCurlySpacing.js
@@ -9,10 +9,6 @@ const schema = [
   },
 ];
 
-const meta = {
-  fixable: 'code',
-};
-
 const sameLine = (left, right) => left.loc.end.line === right.loc.start.line;
 
 const create = (context) => {
@@ -86,6 +82,8 @@ const create = (context) => {
 
 export default {
   create,
-  meta,
-  schema,
+  meta: {
+    fixable: 'code',
+    schema,
+  },
 };

--- a/src/rules/objectTypeDelimiter.js
+++ b/src/rules/objectTypeDelimiter.js
@@ -66,6 +66,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/quotes.js
+++ b/src/rules/quotes.js
@@ -5,10 +5,6 @@ const schema = [
   },
 ];
 
-const meta = {
-  fixable: 'code',
-};
-
 const create = (context) => {
   const double = (context.options[0] || 'double') === 'double';
   const sourceCode = context.getSourceCode();
@@ -42,6 +38,8 @@ const create = (context) => {
 
 export default {
   create,
-  meta,
-  schema,
+  meta: {
+    fixable: 'code',
+    schema,
+  },
 };

--- a/src/rules/requireCompoundTypeAlias.js
+++ b/src/rules/requireCompoundTypeAlias.js
@@ -67,5 +67,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireExactType.js
+++ b/src/rules/requireExactType.js
@@ -5,10 +5,6 @@ const schema = [
   },
 ];
 
-const meta = {
-  fixable: 'code',
-};
-
 const create = (context) => {
   const always = (context.options[0] || 'always') === 'always';
   const sourceCode = context.getSourceCode();
@@ -48,6 +44,8 @@ const create = (context) => {
 
 export default {
   create,
-  meta,
-  schema,
+  meta: {
+    fixable: 'code',
+    schema,
+  },
 };

--- a/src/rules/requireIndexerName.js
+++ b/src/rules/requireIndexerName.js
@@ -37,6 +37,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/requireInexactType.js
+++ b/src/rules/requireInexactType.js
@@ -37,5 +37,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -73,5 +73,7 @@ const create = iterateFunctionNodes((context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireReadonlyReactProps.js
+++ b/src/rules/requireReadonlyReactProps.js
@@ -185,5 +185,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -161,5 +161,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireTypesAtTop.js
+++ b/src/rules/requireTypesAtTop.js
@@ -72,5 +72,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -151,6 +151,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/requireVariableType.js
+++ b/src/rules/requireVariableType.js
@@ -76,5 +76,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/semi.js
+++ b/src/rules/semi.js
@@ -63,6 +63,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -215,6 +215,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -27,6 +27,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/spaceBeforeGenericBracket.js
+++ b/src/rules/spaceBeforeGenericBracket.js
@@ -59,6 +59,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -15,6 +15,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/spreadExactType.js
+++ b/src/rules/spreadExactType.js
@@ -27,5 +27,7 @@ const create = (context) => ({
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/typeIdMatch.js
+++ b/src/rules/typeIdMatch.js
@@ -30,5 +30,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -91,6 +91,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/unionIntersectionSpacing.js
+++ b/src/rules/unionIntersectionSpacing.js
@@ -79,6 +79,6 @@ export default {
   create,
   meta: {
     fixable: 'code',
+    schema,
   },
-  schema,
 };

--- a/src/rules/useFlowType.js
+++ b/src/rules/useFlowType.js
@@ -54,5 +54,7 @@ const create = (context) => {
 
 export default {
   create,
-  schema,
+  meta: {
+    schema,
+  },
 };

--- a/src/rules/useReadOnlySpread.js
+++ b/src/rules/useReadOnlySpread.js
@@ -1,11 +1,3 @@
-const meta = {
-  messages: {
-    readonlySpread:
-      'Flow type with spread property and all readonly properties must be '
-    + 'wrapped in \'$ReadOnly<…>\' to prevent accidental loss of readonly-ness.',
-  },
-};
-
 const create = (context) => ({
   TypeAlias(node) {
     if (node.right.type === 'GenericTypeAnnotation' && node.right.id.name === '$ReadOnly') {
@@ -39,5 +31,11 @@ const create = (context) => ({
 
 export default {
   create,
-  meta,
+  meta: {
+    messages: {
+      readonlySpread:
+        'Flow type with spread property and all readonly properties must be '
+      + 'wrapped in \'$ReadOnly<…>\' to prevent accidental loss of readonly-ness.',
+    },
+  },
 };

--- a/src/rules/validSyntax.js
+++ b/src/rules/validSyntax.js
@@ -31,6 +31,6 @@ export default {
   create,
   meta: {
     deprecated: true,
+    schema,
   },
-  schema,
 };

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -75,7 +75,7 @@ for (const ruleName of reportingRules) {
       RuleTester.describe(ruleName, () => {
         RuleTester.describe('misconfigured', () => {
           RuleTester.it(JSON.stringify(misconfiguration.options), () => {
-            const schema = plugin.rules[ruleName].schema && plugin.rules[ruleName].schema;
+            const schema = plugin.rules[ruleName].meta && plugin.rules[ruleName].meta.schema && plugin.rules[ruleName].meta.schema;
 
             if (!schema) {
               throw new Error('No schema.');


### PR DESCRIPTION
This fixes issues in which the `schema` isn't applied under the `meta` property. I was a little confused because was some code under `tests/rules/index.js` that enforced that rules were under `rule.schema` instead of `rule.meta.schema` (that I had to change). I'm not sure where that code came from, but these changes prevent ESLint from complaining, aligning with [the documentation](https://eslint.org/docs/latest/extend/custom-rules) - and all the tests still pass.

Closes #42

<details>

<summary>Before</summary>

```console
$ yarn test |& grep 'Please add a schema'
(node:37184) DeprecationWarning: "array-style-complex-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "array-style-complex-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "array-style-simple-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "array-style-simple-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "arrow-parens with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "arrow-parens with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "boolean-style with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "boolean-style with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "delimiter-dangle with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "delimiter-dangle with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "generic-spacing with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "generic-spacing with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "interface-id-match with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "interface-id-match with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "newline-after-flow-annotation with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "newline-after-flow-annotation with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-flow-fix-me-comments with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-flow-fix-me-comments with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-flow-suppressions-in-strict-files with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-flow-suppressions-in-strict-files with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-weak-types with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "no-weak-types with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "object-type-curly-spacing with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "object-type-curly-spacing with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "object-type-delimiter with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "object-type-delimiter with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "quotes with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "quotes with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-compound-type-alias with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-compound-type-alias with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-inexact-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-inexact-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-indexer-name with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-indexer-name with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-exact-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-exact-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-parameter-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-parameter-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-readonly-react-props with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-readonly-react-props with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-return-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-return-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-types-at-top with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-types-at-top with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-valid-file-annotation with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-valid-file-annotation with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-variable-type with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "require-variable-type with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "semi with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "semi with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "sort-keys with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "sort-keys with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-after-type-colon with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-after-type-colon with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-before-generic-bracket with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-before-generic-bracket with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-before-type-colon with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "space-before-type-colon with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "type-id-match with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "type-id-match with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "type-import-style with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "type-import-style with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "union-intersection-spacing with @babel/eslint-parser parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
(node:37184) DeprecationWarning: "union-intersection-spacing with hermes-eslint parser" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/latest/extend/custom-rules#options-schemas
```

</details>

<details>

<summary>After</summary>

```console
$ yarn test |& grep 'Please add a schema'
$ yarn test
...
      ✔ function x(foo: string = "1") {}
      ✔ function x(foo: Type = bar()) {}


  3020 passing (9s)

Done in 13.13s.
```

</details>