### PR TITLE
Fix defineFlowType getting scope on older version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-ft-flow",
   "description": "Flowtype linting rules for ESLint by flow-typed",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "MIT",
   "main": "./dist/index.js",
   "repository": {

--- a/src/rules/defineFlowType.js
+++ b/src/rules/defineFlowType.js
@@ -59,8 +59,7 @@ const create = (context) => {
       }
     },
     Program(node) {
-      const newGetScope = context.sourceCode.getScope;
-      if (newGetScope) {
+      if (context.sourceCode?.getScope) {
         globalScope = context.sourceCode.getScope(node);
       } else {
         globalScope = context.getScope();


### PR DESCRIPTION
Closes #52 the previous code assumed `context.sourceCode` always exists but does not on older eslint versions