### PR TITLE
Add TS syntax support to require-readonly-react-props

### DIFF
--- a/.README/rules/require-readonly-react-props.md
+++ b/.README/rules/require-readonly-react-props.md
@@ -96,4 +96,21 @@ Optionally, you can enable support for [implicit exact Flow types](https://mediu
 ```
 
 
+If you’re using [experimental TypeScript syntax](https://github.com/facebook/flow/blob/main/Changelog.md#02290) via the `experimental.ts_syntax=true` Flow option, you can adjust this lint rule to check for that syntax, e.g., `Readonly` versus `$ReadOnly`.
+
+
+```js
+{
+    "rules": {
+        "ft-flow/require-readonly-react-props": [
+            2,
+            {
+                "useExperimentalTypeScriptSyntax": true
+            }
+        ]
+    }
+}
+```
+
+
 <!-- assertions requireReadonlyReactProps -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,6 @@ Run with `yarn lint`.
   * Use [./.README/rules/require-valid-file-annotation.md](./.README/rules/require-valid-file-annotation.md) as a template.
   * Ensure that rule documentation document includes `<!-- assertions spaceAfterTypeColon -->` declaration.
 2. Update [./.README/README.md](/.README/README.md) to include the new rule.
-3. Run `npm run create-readme` to generate the new `README.md` (you must be on `master` branch for this command to work)
+3. Run `yarn create-readme` to generate the new `README.md` (you must be on `master` branch for this command to work)
 
 Note: Sections "The following patterns are considered problems:" and "The following patterns are not considered problems:" are **generated automatically** using the test cases.

--- a/README.md
+++ b/README.md
@@ -105,14 +105,9 @@ pnpm add -D eslint-plugin-ft-flow eslint hermes-eslint
 ```json
 {
   "parser": "hermes-eslint",
-  "plugins": [
-    "ft-flow"
-  ],
+  "plugins": ["ft-flow"],
   "rules": {
-    "ft-flow/boolean-style": [
-      2,
-      "boolean"
-    ],
+    "ft-flow/boolean-style": [2, "boolean"]
     // ... more rules
   },
   "settings": {
@@ -135,9 +130,7 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 
 ```json
 {
-  "extends": [
-    "plugin:ft-flow/recommended"
-  ]
+  "extends": ["plugin:ft-flow/recommended"]
 }
 ```
 
@@ -3946,6 +3939,23 @@ Optionally, you can enable support for [implicit exact Flow types](https://mediu
             2,
             {
                 "useImplicitExactTypes": true
+            }
+        ]
+    }
+}
+```
+
+
+If you’re using [experimental TypeScript syntax](https://github.com/facebook/flow/blob/main/Changelog.md#02290) via the `experimental.ts_syntax=true` Flow option, you can adjust this lint rule to check for that syntax, e.g., `Readonly` versus `$ReadOnly`.
+
+
+```js
+{
+    "rules": {
+        "ft-flow/require-readonly-react-props": [
+            2,
+            {
+                "useExperimentalTypeScriptSyntax": true
             }
         ]
     }

--- a/tests/rules/assertions/requireReadonlyReactProps.js
+++ b/tests/rules/assertions/requireReadonlyReactProps.js
@@ -11,6 +11,19 @@ export default {
       ],
     },
     {
+      code: 'type Props = { }; class Foo extends React.Component<Props> { }',
+      errors: [
+        {
+          message: 'Props must be Readonly',
+        },
+      ],
+      options: [
+        {
+          useExperimentalTypeScriptSyntax: true,
+        },
+      ],
+    },
+    {
       code: 'type OtherProps = { foo: string }; class Foo extends React.Component<OtherProps> { }',
       errors: [
         {
@@ -119,6 +132,24 @@ export default {
       ],
     },
     {
+      //                                           vvvvv
+      code: 'type Props = { }; function Foo(props: Props) { return <p /> }',
+      errors: [
+        {
+          column: 39,
+          endColumn: 44,
+          endLine: 1,
+          line: 1,
+          message: 'Props must be Readonly',
+        },
+      ],
+      options: [
+        {
+          useExperimentalTypeScriptSyntax: true,
+        },
+      ],
+    },
+    {
       code: 'type Props = { }; function Foo(props: Props) { return foo ? <p /> : <span /> }',
       errors: [
         {
@@ -148,6 +179,14 @@ export default {
     // class components
     {
       code: 'class Foo extends React.Component<$ReadOnly<{}>> { }',
+    },
+    {
+      code: 'class Foo extends React.Component<Readonly<{}>> { }',
+      options: [
+        {
+          useExperimentalTypeScriptSyntax: true,
+        },
+      ],
     },
     {
       code: 'type Props = $ReadOnly<{}>; class Foo extends React.Component<Props> { }',
@@ -250,6 +289,14 @@ export default {
     },
     {
       code: 'type Props = $ReadOnly<{}>; function Foo(props: Props) { }',
+    },
+    {
+      code: 'type Props = Readonly<{}>; function Foo(props: Props) { }',
+      options: [
+        {
+          useExperimentalTypeScriptSyntax: true,
+        },
+      ],
     },
     {
       code: 'type Props = {}; function Foo(props: OtherProps) { }',


### PR DESCRIPTION
Per the [changelog for 0.229.0](https://github.com/facebook/flow/blob/main/Changelog.md#02290), enabling `experimental.ts_syntax=true` allows some TypeScript syntax, e.g., `Readonly` versus `$ReadOnly`.

This PR adds optional support for this syntax to [`require-readonly-react-props`](https://github.com/ShortboxedInc/eslint-plugin-ft-flow?tab=readme-ov-file#require-readonly-react-props) via `useExperimentalTypeScriptSyntax`.

This is my first PR for this repo, so any feedback is appreciated. 🙂 