### PR TITLE
Add hasSuggestions to sortTypeUnionIntersection

### DIFF
--- a/src/rules/sortTypeUnionIntersectionMembers.js
+++ b/src/rules/sortTypeUnionIntersectionMembers.js
@@ -228,5 +228,6 @@ export default {
         type: 'object',
       },
     ],
+    hasSuggestions: true,
   },
 };


### PR DESCRIPTION
Without this, eslint errors for me:

Oops! Something went wrong! :(

ESLint: 8.57.0


Rules with suggestions must set the `meta.hasSuggestions` property to `true`.