### PR TITLE
Fix issue #63: Typo in peer dependency version causes npm error since 3.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0 | ^9.0.0",
+    "eslint": "^8.56.0 || ^9.0.0",
     "hermes-eslint": ">=0.15.0"
   },
   "keywords": [


### PR DESCRIPTION
Fixes #63: Typo in peer dependency version causes npm error since 3.0.10